### PR TITLE
Reduce Area Usage

### DIFF
--- a/src/PE.v
+++ b/src/PE.v
@@ -8,8 +8,8 @@ module PE #(
     input wire signed [WIDTH-1:0] a_in,
     input wire signed [WIDTH-1:0] b_in,
 
-    output reg [WIDTH-1:0] a_out,
-    output reg [WIDTH-1:0] b_out,
+    output reg signed [WIDTH-1:0] a_out,
+    output reg signed [WIDTH-1:0] b_out,
 
     output reg signed [WIDTH-1:0] c_out
 );

--- a/src/PE.v
+++ b/src/PE.v
@@ -11,7 +11,7 @@ module PE #(
     output reg [WIDTH-1:0] a_out,
     output reg [WIDTH-1:0] b_out,
 
-    output reg signed [2*WIDTH-1:0] c_out
+    output reg signed [WIDTH-1:0] c_out
 );
 
     always @(posedge clk or posedge rst) begin

--- a/src/config.json
+++ b/src/config.json
@@ -13,7 +13,7 @@
 
   "//": "PL_TARGET_DENSITY_PCT - You can increase this if Global Placement fails with error GPL-0302.",
   "//": "Users have reported that values up to 80 worked well for them.",
-  "PL_TARGET_DENSITY_PCT": 85,
+  "PL_TARGET_DENSITY_PCT": 80,
 
   "//": "CLOCK_PERIOD - Increase this in case you are getting setup time violations.",
   "//": "The value is in nanoseconds, so 20ns == 50MHz.",

--- a/src/control_unit.v
+++ b/src/control_unit.v
@@ -7,16 +7,14 @@ module control_unit (
 
     // Memory interface  
     output reg mem_load_mat,
-    output reg [2:0] mem_addr, // Adjusted to 3 bits for matrix and element selection
+    output reg [2:0] mem_addr,
 
     // MMU feeding control
     output reg mmu_en,
-    output reg [2:0] mmu_cycle // Renamed from mmu_cycle, adjusted to 3 bits
+    output reg [2:0] mmu_cycle
 );
 
-    // Instruction decoding
-    wire load_en = instrn;          // Bit 0: load enable
-    // Bit 7: ignored as specified
+    wire load_en = instrn; 
 
     // STATES
     localparam [1:0] S_IDLE                  = 2'b00;
@@ -59,7 +57,7 @@ module control_unit (
                 end
             end
 
-			default begin
+			default: begin
 				next_state = S_IDLE;
 			end
         endcase
@@ -76,13 +74,13 @@ module control_unit (
             mem_addr <= 0;
         end else begin
             state <= next_state;
+            mem_addr <= 0;
             case (state)
                 S_IDLE: begin
                     mat_elems_loaded <= 0;
                     mmu_cycle <= 0;
                     mmu_en <= 0;
                     mem_load_mat <= load_en;
-                    mem_addr <= 0;
                 end
 
                 S_LOAD_MATS: begin
@@ -92,7 +90,6 @@ module control_unit (
                         mem_addr <= mat_elems_loaded + 1;
                     end else begin
                         mem_load_mat <= 0;
-                        mem_addr <= 0;
                     end
 
                     if (mat_elems_loaded == 3'b111) begin 
@@ -104,20 +101,14 @@ module control_unit (
                 S_MMU_FEED_COMPUTE_WB: begin
                     mmu_en <= 1;
                     mem_load_mat <= 0;
-                    mem_addr <= 0;
 					mmu_cycle <= mmu_cycle + 1;
                 end
 				
-				default begin
+				default: begin
 					mat_elems_loaded <= 0;
                     mmu_cycle <= 0;
                     mmu_en <= 0;
                     mem_load_mat <= load_en;
-                    if (load_en) begin
-                        mem_addr <= 0;
-                    end else begin
-                        mem_addr <= 0;
-                    end
 				end
             endcase
         end

--- a/src/mmu_feeder.v
+++ b/src/mmu_feeder.v
@@ -11,7 +11,7 @@ module mmu_feeder (
     input wire [7:0] input0, input1, input2, input3,
 
     /* systolic array -> feeder */
-    input wire signed [15:0] c00, c01, c10, c11,
+    input wire signed [7:0] c00, c01, c10, c11,
 
     /* feeder -> mmu */
     output reg clear,
@@ -86,18 +86,10 @@ module mmu_feeder (
         host_outdata = 8'b0; // Default to avoid latch
         if (en) begin
             case (output_count)
-                2'b00: host_outdata = (c00[15] && c00[15:8] != 8'hFF) ? -8'sd128 :
-                                      (!c00[15] && c00[15:8] != 8'h00) ? 8'sd127 :
-                                      c00[7:0];
-                2'b01: host_outdata = (c01[15] && c01[15:8] != 8'hFF) ? -8'sd128 :
-                                      (!c01[15] && c01[15:8] != 8'h00) ? 8'sd127 :
-                                      c01[7:0];
-                2'b10: host_outdata = (c10[15] && c10[15:8] != 8'hFF) ? -8'sd128 :
-                                      (!c10[15] && c10[15:8] != 8'h00) ? 8'sd127 :
-                                      c10[7:0];
-                2'b11: host_outdata = (c11[15] && c11[15:8] != 8'hFF) ? -8'sd128 :
-                                      (!c11[15] && c11[15:8] != 8'h00) ? 8'sd127 :
-                                      c11[7:0];
+                2'b00: host_outdata = c00;
+                2'b01: host_outdata = c01;
+                2'b10: host_outdata = c10;
+                2'b11: host_outdata = c11;
                 default: host_outdata = 8'b0;
             endcase
         end

--- a/src/mmu_feeder.v
+++ b/src/mmu_feeder.v
@@ -11,7 +11,7 @@ module mmu_feeder (
     input wire [7:0] input0, input1, input2, input3,
 
     /* systolic array -> feeder */
-    input wire signed [7:0] c00, c01, c10, c11,
+    input wire [7:0] c00, c01, c10, c11,
 
     /* feeder -> mmu */
     output reg clear,

--- a/src/systolic_array_2x2.v
+++ b/src/systolic_array_2x2.v
@@ -10,16 +10,16 @@ module systolic_array_2x2 #(
     input wire [WIDTH-1:0] b_data0,
     input wire [WIDTH-1:0] b_data1,
 
-    output wire [2*WIDTH-1:0] c00,
-    output wire [2*WIDTH-1:0] c01,
-    output wire [2*WIDTH-1:0] c10,
-    output wire [2*WIDTH-1:0] c11
+    output wire [WIDTH-1:0] c00,
+    output wire [WIDTH-1:0] c01,
+    output wire [WIDTH-1:0] c10,
+    output wire [WIDTH-1:0] c11
 );
 
     // Internal signals between PEs
     wire [WIDTH-1:0] a_wire [0:1][0:2];
     wire [WIDTH-1:0] b_wire [0:2][0:1];
-    wire [15:0] c_array [0:1][0:1];
+    wire [7:0] c_array [0:1][0:1];
 
     // Input loading at top-left
     assign a_wire[0][0] = a_data0;

--- a/src/tpu.v
+++ b/src/tpu.v
@@ -28,7 +28,7 @@ module tt_um_tpu (
     wire [7:0] weight0, weight1, weight2, weight3;
     wire [7:0] input0, input1, input2, input3;
 
-    wire [15:0] outputs [0:3]; // raw accumulations (16-bit)
+    wire [7:0] outputs [0:3]; // raw accumulations (16-bit)
     wire [7:0] out_data; // sent to CPU
     // Ports of the systolic Array
     wire [7:0] a_data0, b_data0, a_data1, b_data1;


### PR DESCRIPTION
Keeps density at a safe 80.
All operands in 8 bits, massively reduces area usage.
If it overflows, it wraps at `-128` considering 2's complement, no matter if the real result is +ve or -ve.