### PR TITLE
Possible Hold Violation Fix

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -23,6 +23,7 @@ project:
     - "memory.v"
     - "control_unit.v"
     - "mmu_feeder.v"
+    - "delay_cell.v"
 
 # The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
 # This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).

--- a/src/config.json
+++ b/src/config.json
@@ -20,7 +20,7 @@
   "CLOCK_PERIOD": 20,
 
   "//": "Hold slack margin - Increase them in case you are getting hold violations.",
-  "PL_RESIZER_HOLD_SLACK_MARGIN": 0.3,
+  "PL_RESIZER_HOLD_SLACK_MARGIN": 0.8,
   "GRT_RESIZER_HOLD_SLACK_MARGIN": 0.8,
 
   "//": "RUN_LINTER, LINTER_INCLUDE_PDK_MODELS - Disabling the linter is not recommended!",

--- a/src/delay_cell.v
+++ b/src/delay_cell.v
@@ -2,5 +2,5 @@ module buffer (
     input wire A,
     output wire X
 );
-    assign #1 X = A;
+    assign X = A;
 endmodule

--- a/src/delay_cell.v
+++ b/src/delay_cell.v
@@ -1,0 +1,6 @@
+module buffer (
+    input wire A,
+    output wire X
+);
+    assign #1 X = A;
+endmodule

--- a/src/tpu.v
+++ b/src/tpu.v
@@ -37,6 +37,10 @@ module tt_um_tpu (
     wire done;
     wire [1:0] state;
 
+    wire [7:0] stage1;
+    wire [7:0] stage2;
+    wire [7:0] stage3;
+
     // Module Instantiations
     memory mem (
         .clk(clk),
@@ -94,7 +98,15 @@ module tt_um_tpu (
         .host_outdata(out_data)
     );
 
-    assign uo_out = out_data;
+    genvar i;
+    generate
+        for (i = 0; i < 8; i = i + 1) begin : buf_loop
+            (* dont_touch = "true" *) buffer buf1 (.A(out_data[i]), .X(stage1[i]));
+            (* dont_touch = "true" *) buffer buf2 (.A(stage1[i]), .X(stage2[i]));
+            (* dont_touch = "true" *) buffer buf3 (.A(stage2[i]), .X(stage3[i]));
+        end
+    endgenerate
+    assign uo_out = stage3;
     assign uio_out = {done, state, 5'b0};
     assign uio_oe = 8'b11100000;
 

--- a/src/tpu.v
+++ b/src/tpu.v
@@ -101,9 +101,9 @@ module tt_um_tpu (
     genvar i;
     generate
         for (i = 0; i < 8; i = i + 1) begin : buf_loop
-            (* dont_touch = "true" *) buffer buf1 (.A(out_data[i]), .X(stage1[i]));
-            (* dont_touch = "true" *) buffer buf2 (.A(stage1[i]), .X(stage2[i]));
-            (* dont_touch = "true" *) buffer buf3 (.A(stage2[i]), .X(stage3[i]));
+            (* keep *) buffer buf1 (.A(out_data[i]), .X(stage1[i]));
+            (* keep *) buffer buf2 (.A(stage1[i]), .X(stage2[i]));
+            (* keep *) buffer buf3 (.A(stage2[i]), .X(stage3[i]));
         end
     endgenerate
     assign uo_out = stage3;

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,6 +14,7 @@ PROJECT_SOURCES = tpu.v \
 					systolic_array_2x2.v \
 					control_unit.v \
 					PE.v \
+					delay_cell.v \
 					mmu_feeder.v \
 					memory.v
 
@@ -57,7 +58,7 @@ test-top:
 	$(MAKE) sim \
 		TOPLEVEL=tb \
 		MODULE=test_tpu \
-		VERILOG_SOURCES="$(WAVES_ROOT)/tpu/tb.v $(addprefix $(SRC_DIR)/,tpu.v systolic_array_2x2.v PE.v mmu_feeder.v control_unit.v memory.v)" \
+		VERILOG_SOURCES="$(WAVES_ROOT)/tpu/tb.v $(addprefix $(SRC_DIR)/,tpu.v delay_cell.v systolic_array_2x2.v PE.v mmu_feeder.v control_unit.v memory.v)" \
 		PYTHONPATH=$(WAVES_ROOT)/tpu \
 		WAVES_DIR=$(WAVES_ROOT)/tpu/wave \
 		COMPILE_ARGS='$(COMPILE_ARGS) -DVCD_PATH="\"$(WAVES_ROOT)/tpu/wave/tpu_tb_$(TIMESTAMP).vcd\""'
@@ -67,7 +68,7 @@ test-nn:
 	$(MAKE) sim \
 		TOPLEVEL=tb \
 		MODULE=neural_inference \
-		VERILOG_SOURCES="$(WAVES_ROOT)/tpu/tb.v $(addprefix $(SRC_DIR)/,tpu.v systolic_array_2x2.v PE.v mmu_feeder.v control_unit.v memory.v)" \
+		VERILOG_SOURCES="$(WAVES_ROOT)/tpu/tb.v $(addprefix $(SRC_DIR)/,tpu.v delay_cell.v systolic_array_2x2.v PE.v mmu_feeder.v control_unit.v memory.v)" \
 		PYTHONPATH=$(WAVES_ROOT)/tpu \
 		WAVES_DIR=$(WAVES_ROOT)/tpu/wave \
 		COMPILE_ARGS='$(COMPILE_ARGS) -DVCD_PATH="\"$(WAVES_ROOT)/tpu/wave/tpu_tb_$(TIMESTAMP).vcd\""'


### PR DESCRIPTION
With new custom buffers that are forced in...there are now no hold violations on `uo_out` ports.
Instead we have the below:
The first is very tolerable.
The second is not even on a used port.
```bash
Startpoint: rst_n (input port clocked by clk)
Endpoint: _4066_ (removal check against rising-edge clock clk)
Path Group: asynchronous
Path Type: min
Corner: ss

  Delay    Time   Description
---------------------------------------------------------
   0.00    0.00   clock clk (rise edge)
   0.00    0.00   clock network delay (propagated)
   0.50    0.50 ^ input external delay
   0.00    0.50 ^ rst_n (in)
   0.34    0.84 ^ input1/X (sky130_fd_sc_hd__clkbuf_2)
   0.45    1.29 ^ fanout141/X (sky130_fd_sc_hd__clkbuf_2)
   0.00    1.29 ^ _4066_/RESET_B (sky130_fd_sc_hd__dfrtp_2)
           1.29   data arrival time

   0.00    0.00   clock clk (rise edge)
   0.61    0.61   clock network delay (propagated)
   0.10    0.71   clock uncertainty
   0.00    0.71   clock reconvergence pessimism
           0.71 ^ _4066_/CLK (sky130_fd_sc_hd__dfrtp_2)
   0.64    1.34   library removal time
           1.34   data required time
---------------------------------------------------------
           1.34   data required time
          -1.29   data arrival time
---------------------------------------------------------
          -0.05   slack (VIOLATED)


Startpoint: _4153_ (rising edge-triggered flip-flop clocked by clk)
Endpoint: uio_out[5] (output port clocked by clk)
Path Group: clk
Path Type: min
Corner: ff

  Delay    Time   Description
---------------------------------------------------------
   0.00    0.00   clock clk (rise edge)
   0.34    0.34   clock network delay (propagated)
   0.00    0.34 ^ _4153_/CLK (sky130_fd_sc_hd__dfrtp_4)
   0.32    0.65 ^ _4153_/Q (sky130_fd_sc_hd__dfrtp_4)
   0.00    0.65 ^ uio_out[5] (out)
           0.65   data arrival time

   0.00    0.00   clock clk (rise edge)
   0.00    0.00   clock network delay (propagated)
   0.10    0.10   clock uncertainty
   0.00    0.10   clock reconvergence pessimism
   2.50    2.60   output external delay
           2.60   data required time
---------------------------------------------------------
           2.60   data required time
          -0.65   data arrival time
---------------------------------------------------------
          -1.95   slack (VIOLATED)
```