### PR TITLE
Make Neural Inference Work in GHA

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -44,7 +44,7 @@ endif
 # Allow sharing configuration between design and testbench via `include`:
 COMPILE_ARGS 		+= -I$(SRC_DIR)
 
-.PHONY: all test-top test-memory test-systolic-array test-control-unit test-mmu-feeder
+.PHONY: all test-top test-memory test-systolic-array test-control-unit test-mmu-feeder test-nn
 
 all:
 	$(MAKE) test-top
@@ -52,6 +52,7 @@ all:
 	$(MAKE) test-systolic-array
 	$(MAKE) test-control-unit
 	$(MAKE) test-mmu-feeder
+	$(MAKE) test-nn
 
 test-top:
 	$(MAKE) clean

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,5 @@
 pytest==8.3.4
 cocotb==1.9.2
 numpy==2.1.3
-torch
+torch --index-url https://download.pytorch.org/whl/cpu
 torchvision

--- a/test/tpu/neural_inference.py
+++ b/test/tpu/neural_inference.py
@@ -42,7 +42,7 @@ async def test_neural_network_inference(dut):
 
     # Load PyTorch QAT weights
     try:
-        model_data = torch.load('tpu/qat_model.pt', weights_only=True)
+        model_data = torch.load('tpu/qat_model.pt', weights_only=False)
         weights = model_data['weights']
         scales = model_data['scales']
     except Exception as e:

--- a/test/tpu/neural_inference.py
+++ b/test/tpu/neural_inference.py
@@ -21,7 +21,7 @@ torch.serialization.add_safe_globals([np.core.multiarray._reconstruct])
 ##########################################################################################
 ###### Skipped Neural Network Training - Model is loaded from pre-trained checkpoint #####
 
-@cocotb.test
+@cocotb.test()
 async def test_neural_network_inference(dut):
     dut._log.info("Start")
     clock = Clock(dut.clk, 20, units="ns")

--- a/test/tpu/neural_inference.py
+++ b/test/tpu/neural_inference.py
@@ -1,139 +1,22 @@
-from test_tpu import matmul
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import ClockCycles, RisingEdge
 import numpy as np
-
-"""
-The coolest part: setting up QAT in PyTorch
-"""
 import torch
-import torch.nn as nn
-import torch.optim as optim
-import torchvision
-import torchvision.transforms as transforms
-from torch.quantization import QuantStub, DeQuantStub, prepare_qat, convert
-import numpy as np
+from test_tpu import matmul
 
-class FCNet(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.quant = QuantStub()
-        self.fc1 = nn.Linear(784, 128)
-        self.relu = nn.ReLU()
-        self.dequant_act = DeQuantStub()
-        self.activation_quant = QuantStub()
-        self.fc2 = nn.Linear(128, 10)
-        self.dequant = DeQuantStub()
+def quantize_activation(x, scale, zero_point):
+    """Quantize floating point values to 8-bit integers"""
+    return np.clip(np.round(x / scale + zero_point), -128, 127).astype(np.int8)
 
-    def forward(self, x):
-        x = self.quant(x)
-        x = self.fc1(x)
-        x = self.relu(x)
-        x = self.dequant_act(x)
-        x = self.activation_quant(x)
-        x = self.fc2(x)
-        x = self.dequant(x)
-        return x
+async def reset_dut(dut):
+    """Reset the DUT by asserting rst_n low for 10 clock cycles, then high."""
+    dut.rst_n.value = 0
+    await ClockCycles(dut.clk, 10)
+    dut.rst_n.value = 1
+    await ClockCycles(dut.clk, 10)
 
-def prepare_model(model, qconfig='fbgemm'):
-    model.qconfig = torch.quantization.get_default_qat_qconfig(qconfig)
-    model = prepare_qat(model, inplace=False)
-    return model
-
-def train_model(model, train_loader, epochs=5):
-    criterion = nn.CrossEntropyLoss()
-    optimizer = optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
-    model.train()
-    for epoch in range(epochs):
-        running_loss = 0.0
-        for i, (images, labels) in enumerate(train_loader):
-            images = images.view(-1, 784)
-            optimizer.zero_grad()
-            outputs = model(images)
-            loss = criterion(outputs, labels)
-            loss.backward()
-            optimizer.step()
-            running_loss += loss.item()
-            if i % 100 == 99:
-                print(f'[Epoch {epoch + 1}, Batch {i + 1}] Loss: {running_loss / 100:.4f}')
-                running_loss = 0.0
-
-# Set quantization backend
-torch.backends.quantized.engine = 'fbgemm'
-
-# Data loading
-transform = transforms.Compose([transforms.ToTensor()])
-train_dataset = torchvision.datasets.MNIST(root='./data', train=True, download=True, transform=transform)
-test_dataset = torchvision.datasets.MNIST(root='./data', train=False, download=True, transform=transform)
-train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=64, shuffle=True)
-test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=64, shuffle=False)
-
-# Train and quantize model
-model = FCNet()
-model = prepare_model(model, qconfig='fbgemm')
-train_model(model, train_loader)
-
-# Convert to quantized model
-model.eval()
-model = convert(model)
-
-# Extract scales and weights
-weights = {}
-weights['fc1'] = model.fc1.weight().int_repr().numpy().astype(np.int8)
-weights['fc2'] = model.fc2.weight().int_repr().numpy().astype(np.int8)
-
-# Get scales from quantization parameters
-fc1_activation_scale = model.activation_quant.scale.item()
-scales = {
-    'fc1_activation_scale': fc1_activation_scale,
-    'fc2_output_scale': 1.0  # No quantization on output
-}
-
-model_data = {
-    'weights': weights,
-    'scales': scales
-}
-torch.save(model_data, 'tpu/qat_model.pt')
-
-# Save test data
-test_images, test_labels = next(iter(test_loader))
-test_images = test_images[:3].view(-1, 784)
-scale = 255 / 1.0
-zero_point = -128
-test_images_int8 = torch.clamp(torch.round(test_images * scale + zero_point), -128, 127).to(torch.int8).numpy()
-test_labels = test_labels[:3].numpy()
-np.savez('tpu/mnist_test_data.npz', images=test_images_int8, labels=test_labels)
-
-# Test accuracy
-correct = 0
-total = 0
-model.eval()
-with torch.no_grad():
-    for images, labels in test_loader:
-        images = images.view(-1, 784)
-        outputs = model(images)
-        _, predicted = torch.max(outputs, 1)
-        total += labels.size(0)
-        correct += (predicted == labels).sum().item()
-print(f'Test Accuracy: {100 * correct / total:.2f}%')
-
-# Save test images and labels for cocotb (first 3 images for demo)
-test_images, test_labels = next(iter(test_loader))
-test_images = test_images[:3].view(-1, 784)
-# Quantize images to int8: [0, 1] -> [-128, 127]
-scale = 255 / 1.0
-zero_point = -128
-test_images_int8 = torch.clamp(torch.round(test_images * scale + zero_point), -128, 127).to(torch.int8).numpy()
-test_labels = test_labels[:3].numpy()
-np.savez('tpu/mnist_test_data.npz', images=test_images_int8, labels=test_labels)
-
-torch.serialization.add_safe_globals([np.core.multiarray._reconstruct])
-
-##########################################################################################
-###### Ran Neural Network Training in global space so time is not counted in DUT Sim #####
-
-@cocotb.test
+@cocotb.test()
 async def test_neural_network_inference(dut):
     dut._log.info("Start")
     clock = Clock(dut.clk, 20, units="ns")
@@ -143,7 +26,7 @@ async def test_neural_network_inference(dut):
 
     # Load PyTorch QAT weights
     try:
-        model_data = torch.load('tpu/qat_model.pt', weights_only=False)
+        model_data = torch.load('tpu/qat_model.pt', weights_only=True)
         weights = model_data['weights']
         scales = model_data['scales']
     except Exception as e:
@@ -169,11 +52,13 @@ async def test_neural_network_inference(dut):
         dut._log.info(f"Processing test image {img_idx + 1}/{num_test_images}")
         X = test_images[img_idx:img_idx+1, :]  # 1x784, int8
 
+        # Layer 1: Z1 = X @ W1^T + ReLU
         Z1_raw = await matmul(dut, X, W1, transpose=True, relu=True)  # 1x128
 
+        # Quantize activations manually
         Z1_quantized = quantize_activation(Z1_raw, fc1_activation_scale, zero_point=0)
 
-        # Layer 2: Z2 = Z1_quantized @ W2
+        # Layer 2: Z2 = Z1_quantized @ W2^T
         Z2_raw = await matmul(dut, Z1_quantized, W2, transpose=True, relu=False)
 
         # Dequantize final output for prediction

--- a/test/tpu/neural_inference.py
+++ b/test/tpu/neural_inference.py
@@ -8,6 +8,7 @@ import numpy as np
 The coolest part: setting up QAT in PyTorch
 """
 import torch
+torch.backends.quantized.engine = 'qnnpack'
 import torch.nn as nn
 import torch.optim as optim
 import torchvision

--- a/test/tpu/neural_inference.py
+++ b/test/tpu/neural_inference.py
@@ -6,6 +6,7 @@ import torch
 from test_tpu import matmul
 
 torch.serialization.add_safe_globals([np.core.multiarray._reconstruct])
+torch.serialization.add_safe_globals([numpy.ndarray])
 
 def quantize_activation(x, scale, zero_point):
     """Quantize floating point values to 8-bit integers"""

--- a/test/tpu/neural_inference.py
+++ b/test/tpu/neural_inference.py
@@ -5,6 +5,8 @@ import numpy as np
 import torch
 from test_tpu import matmul
 
+torch.serialization.add_safe_globals([np.core.multiarray._reconstruct])
+
 def quantize_activation(x, scale, zero_point):
     """Quantize floating point values to 8-bit integers"""
     return np.clip(np.round(x / scale + zero_point), -128, 127).astype(np.int8)

--- a/test/tpu/neural_inference.py
+++ b/test/tpu/neural_inference.py
@@ -8,7 +8,6 @@ import numpy as np
 The coolest part: setting up QAT in PyTorch
 """
 import torch
-torch.backends.quantized.engine = 'qnnpack'
 import torch.nn as nn
 import torch.optim as optim
 import torchvision
@@ -105,7 +104,7 @@ class FCNetCustomQuant(nn.Module):
         x = self.fc2(x)
         return x
     
-def prepare_model(model, qconfig='qnnpack'):
+def prepare_model(model, qconfig='fbgemm'):
     model.qconfig = torch.quantization.get_default_qat_qconfig(qconfig)
     model = prepare_qat(model, inplace=False)
     return model

--- a/test/tpu/train_qat_model.py
+++ b/test/tpu/train_qat_model.py
@@ -1,0 +1,110 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torchvision
+import torchvision.transforms as transforms
+from torch.quantization import QuantStub, DeQuantStub, prepare_qat, convert
+import numpy as np
+
+class FCNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.quant = QuantStub()
+        self.fc1 = nn.Linear(784, 128)
+        self.relu = nn.ReLU()
+        self.dequant_act = DeQuantStub()
+        self.activation_quant = QuantStub()
+        self.fc2 = nn.Linear(128, 10)
+        self.dequant = DeQuantStub()
+
+    def forward(self, x):
+        x = self.quant(x)
+        x = self.fc1(x)
+        x = self.relu(x)
+        x = self.dequant_act(x)
+        x = self.activation_quant(x)
+        x = self.fc2(x)
+        x = self.dequant(x)
+        return x
+
+def prepare_model(model, qconfig='fbgemm'):
+    model.qconfig = torch.quantization.get_default_qat_qconfig(qconfig)
+    model = prepare_qat(model, inplace=False)
+    return model
+
+def train_model(model, train_loader, epochs=5):
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
+    model.train()
+    for epoch in range(epochs):
+        running_loss = 0.0
+        for i, (images, labels) in enumerate(train_loader):
+            images = images.view(-1, 784)
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item()
+            if i % 100 == 99:
+                print(f'[Epoch {epoch + 1}, Batch {i + 1}] Loss: {running_loss / 100:.4f}')
+                running_loss = 0.0
+
+# Set quantization backend
+torch.backends.quantized.engine = 'fbgemm'
+
+# Data loading
+transform = transforms.Compose([transforms.ToTensor()])
+train_dataset = torchvision.datasets.MNIST(root='./data', train=True, download=True, transform=transform)
+test_dataset = torchvision.datasets.MNIST(root='./data', train=False, download=True, transform=transform)
+train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=64, shuffle=True)
+test_loader = torch.utils.data.DataLoader(test_dataset, batch_size=64, shuffle=False)
+
+# Train and quantize model
+model = FCNet()
+model = prepare_model(model, qconfig='fbgemm')
+train_model(model, train_loader)
+
+# Convert to quantized model
+model.eval()
+model = convert(model)
+
+# Extract scales and weights
+weights = {}
+weights['fc1'] = model.fc1.weight().int_repr().numpy().astype(np.int8)
+weights['fc2'] = model.fc2.weight().int_repr().numpy().astype(np.int8)
+
+# Get scales from quantization parameters
+fc1_activation_scale = model.activation_quant.scale.item()
+scales = {
+    'fc1_activation_scale': fc1_activation_scale,
+    'fc2_output_scale': 1.0  # No quantization on output
+}
+
+model_data = {
+    'weights': weights,
+    'scales': scales
+}
+torch.save(model_data, 'tpu/qat_model.pt')
+
+# Save test data
+test_images, test_labels = next(iter(test_loader))
+test_images = test_images[:3].view(-1, 784)
+scale = 255 / 1.0
+zero_point = -128
+test_images_int8 = torch.clamp(torch.round(test_images * scale + zero_point), -128, 127).to(torch.int8).numpy()
+test_labels = test_labels[:3].numpy()
+np.savez('tpu/mnist_test_data.npz', images=test_images_int8, labels=test_labels)
+
+# Test accuracy
+correct = 0
+total = 0
+model.eval()
+with torch.no_grad():
+    for images, labels in test_loader:
+        images = images.view(-1, 784)
+        outputs = model(images)
+        _, predicted = torch.max(outputs, 1)
+        total += labels.size(0)
+        correct += (predicted == labels).sum().item()
+print(f'Test Accuracy: {100 * correct / total:.2f}%')


### PR DESCRIPTION
Split training into separate file (only run locally, github actions machine still needs debug). A certain PyTorch `aten::quantize_per_tensor` is not liked by github actions
However, since the quantized data and the model are already on github, we can run forward inference using just those....