### PR TITLE
Fix Antenna Violations

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -23,6 +23,10 @@
   "PL_RESIZER_HOLD_SLACK_MARGIN": 0.5,
   "GRT_RESIZER_HOLD_SLACK_MARGIN": 0.4,
 
+  "//": "Enable antenna diode insertion for fixing antenna ratio violations",
+  "DIODE_INSERTION_STRATEGY": 4,
+  "ANTENNA_DIODE_CELL": "sky130_fd_sc_hd__diode_2",
+
   "//": "RUN_LINTER, LINTER_INCLUDE_PDK_MODELS - Disabling the linter is not recommended!",
   "RUN_LINTER": 1,
   "LINTER_INCLUDE_PDK_MODELS": 1,


### PR DESCRIPTION
Under `GDS_Logs/70-misc-reportmanufacturability`, there was an antenna violation in the report.

Wish I'd known about that earlier, now that the ASIC is taped out... 😢 

Next time, I shouldn't trust Tiny Tapeout flow 100%.

The fix is to insert diodes, as recommended by Gemini.

See Wikipedia [page](https://en.wikipedia.org/wiki/Antenna_effect) on Antenna effect.

As it is said, "If the diode is connected to metal near the gate(s), it can protect the gate oxide. This can be done only on nets with violations, or on every gate (in general by putting such diodes in every library cell)."
